### PR TITLE
The correct and official name for Finnish Transport Infrastructure Ag…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -166,13 +166,13 @@ t:
       fi: "tietosuojaseloste"
   finnish-transport-agency-web:
     en: "Finnish Transport Infrastructure Agency"
-    fi: "Väylä"
+    fi: "Väylävirasto"
     url:
       en: "https://vayla.fi/web/en"
       fi: "https://vayla.fi/"
   finnish-transport-agency-open-data:
     en: "Finnish Transport Infrastructure Agency open data"
-    fi: "Väylän avoin data"
+    fi: "Väyläviraston avoin data"
     url:
       en: "https://vayla.fi/web/en/open-data"
       fi: "https://vayla.fi/avoindata"

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -165,13 +165,13 @@ t:
       fi: "tietosuojaseloste"
   finnish-transport-agency-web:
     en: "Finnish Transport Infrastructure Agency"
-    fi: "Väylä"
+    fi: "Väylävirasto"
     url:
       en: "https://vayla.fi/web/en"
       fi: "https://vayla.fi/"
   finnish-transport-agency-open-data:
     en: "Finnish Transport Infrastructure Agency open data"
-    fi: "Väylän avoin data"
+    fi: "Väyläviraston avoin data"
     url:
       en: "https://vayla.fi/web/en/open-data"
       fi: "https://vayla.fi/avoindata"

--- a/pages/meriliikenne-en.md
+++ b/pages/meriliikenne-en.md
@@ -11,7 +11,7 @@ ref: marine-traffic
 title: Marine traffic
 intro: Open data from Finnish waterways
 links:
-  - ["Väylä", "https://vayla.fi"]
+  - ["Finnish Transport Infrastructure Agency", "https://vayla.fi"]
   - ["Traffic Management Finland", "https://tmfg.fi"]
   - ["Swagger-UI", "https://meri.digitraffic.fi/swagger/"]
   - ["Swagger-kuvaus", "https://meri.digitraffic.fi/swagger/swagger-spec.json"]
@@ -24,7 +24,7 @@ links:
 
 ## General info
 
-Marine traffic information is gathered from Finnish Transport Agency's data sources. Currently open data API provides following information:
+Marine traffic information is gathered from Finnish Transport Infrastructure Agency's data sources. Currently open data API provides following information:
 
 - Marine warnings 
 

--- a/pages/meriliikenne.md
+++ b/pages/meriliikenne.md
@@ -11,7 +11,7 @@ ref: marine-traffic
 title: Meriliikenne
 intro: Avointa dataa Suomen meriltä ja järviltä.
 links:
-  - ["Väylä", "https://vayla.fi"]
+  - ["Väylävirasto", "https://vayla.fi"]
   - ["Traffic Management Finland", "https://tmfg.fi"]
   - ["Swagger-UI", "https://meri.digitraffic.fi/swagger/"]
   - ["Swagger-kuvaus", "https://meri.digitraffic.fi/swagger/swagger-spec.json"]
@@ -24,7 +24,7 @@ links:
 
 ## Yleistä tietoa
 
-Meriliikenteen tiedot syntyvät VTS Finlandin ja Väylän operoimissa ammattimerenkulun tietojärjestelmissä. Avoimet meriliikenteen tiedot sisältävät tällä hetkellä:
+Meriliikenteen tiedot syntyvät VTS Finlandin ja Väyläviraston operoimissa ammattimerenkulun tietojärjestelmissä. Avoimet meriliikenteen tiedot sisältävät tällä hetkellä:
 
 - Merivaroitustiedot. Merivaroitustietojen avulla voidaan hakea voimassa olevat kauppamerenkulun väylien turvalaitepoikkeamat sekä voimassa olevat merivaroitukset.
 

--- a/pages/palvelun-esittely.md
+++ b/pages/palvelun-esittely.md
@@ -19,7 +19,7 @@ links:
     - /sovellukset
   - - Käyttöehdot
     - /kayttoehdot
-  - - Väylän avoin data
+  - - Väyläviraston avoin data
     - https://vayla.fi/avoindata
 published: true
 ---

--- a/pages/rautatieliikenne-en.md
+++ b/pages/rautatieliikenne-en.md
@@ -11,12 +11,12 @@ lang: en
 title: Railway traffic
 intro: Timetables, delays, locations and composition of trains operating in Finland
 links:
-  - ["Väylä", "https://vayla.fi"]
+  - ["Finnish Transport Infrastructure Agency", "https://vayla.fi"]
   - ["Traffic Management Finland", "https://tmfg.fi"]
   - ["Swagger", "https://rata.digitraffic.fi/swagger/index.html"]
 ---
 
-The purpose of this service is to share data of trains operating in Finland. The service is operated by Finnish Transport agency (FTA). The data is sourced from the following applications used in traffic controlling and capacity management: 
+The purpose of this service is to share data of trains operating in Finland. The service is operated by Traffic Management Finland. The data is sourced from the following applications used in traffic controlling and capacity management: 
 
 ![LIIKE]({{ site.baseurl }}{{ "/img/rata/liike.png" }}) ![REAALI]({{ site.baseurl }}{{ "/img/rata/reaali.png" }}) ![LOKI]({{ site.baseurl }}{{ "/img/rata/loki.png" }})
 

--- a/pages/rautatieliikenne.md
+++ b/pages/rautatieliikenne.md
@@ -11,7 +11,7 @@ ref: railway-traffic
 title: Rautatieliikenne
 intro: Junien aikataulut, toteumatiedot, sijainnit ja kokoonpanot.
 links:
-  - ["Väylä", "https://vayla.fi"]
+  - ["Väylävirasto", "https://vayla.fi"]
   - ["Traffic Management Finland", "https://tmfg.fi"]
   - ["Swagger", "https://rata.digitraffic.fi/swagger/index.html"]
 ---

--- a/pages/tieliikenne-en.md
+++ b/pages/tieliikenne-en.md
@@ -11,7 +11,7 @@ lang: en
 ref: road-traffic
 intro: Open data from Finnish roads.
 links:
-  - ["Väylä", "https://vayla.fi"]
+  - ["Väylävirasto", "https://vayla.fi"]
   - ["Traffic Management Finland","https://tmfg.fi"]
   - ["Swagger-UI", "https://tie.digitraffic.fi/swagger/"]
   - ["Swagger-kuvaus", "https://tie.digitraffic.fi/swagger/swagger-spec.json"]

--- a/pages/tieliikenne.md
+++ b/pages/tieliikenne.md
@@ -11,7 +11,7 @@ lang: fi
 ref: road-traffic
 intro: Avointa dataa Suomen tieverkolta.
 links:
-  - - Väylä
+  - - Väylävirasto
     - https://vayla.fi
 ---
 


### PR DESCRIPTION
…ency is now Väylävirasto