### PR TITLE
chore(docs): clarify EMU marking in compositions

### DIFF
--- a/pages/rautatieliikenne.md
+++ b/pages/rautatieliikenne.md
@@ -1059,7 +1059,7 @@ jossa kokoonpano muuttuu.
 
 ![warning]({{ site.baseurl }}{{ "/img/rata/warn.png" }}) Moottorivaunut
 (esimerkiksi tyypit Sm3, Sm4, Sm5) on yleisesti ilmoitettu kokoonpanoissa
-vaunuina.
+vaunuina sekä vetureina.
 
 ### Junan kokoonpanohaku
 


### PR DESCRIPTION
Added clarification that EMUs are marked as a wagon as well as a locomotive. 

(Example: https://rata.digitraffic.fi/api/v1/compositions/2025-06-09/8491)